### PR TITLE
ComponentsとLayoutsについて

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <NuxtLayout>
     <NuxtPage/>
-  </div>
+  </NuxtLayout>
 </template>

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -1,0 +1,36 @@
+<template>
+  <header class="app-bar">
+    <div class="app-bar-title">ToDo App</div>
+    <a href="/" class="app-bar-link">home</a>
+  </header>
+</template>
+
+<style>
+.app-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 64px;
+  background-color: #1976d2;
+  color: white;
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  z-index: 10;
+}
+
+.app-bar-title {
+  font-size: 24px;
+  font-weight: bold;
+}
+
+.app-bar-link {
+  color: white;
+  font-size: 24px;
+  margin-left: 10px;
+  text-decoration: none;
+}
+
+</style>

--- a/components/Atoms/Button.vue
+++ b/components/Atoms/Button.vue
@@ -1,0 +1,36 @@
+<template>
+  <button class="styled" type="button">ホームへ</button>
+</template>
+
+<style>
+.styled {
+  border: 0;
+  line-height: 2.5;
+  padding: 0 20px;
+  font-size: 1rem;
+  text-align: center;
+  color: #fff;
+  text-shadow: 1px 1px 1px #000;
+  border-radius: 10px;
+  background-color: rgba(220, 0, 0, 1);
+  background-image: linear-gradient(
+    to top left,
+    rgba(0, 0, 0, 0.2),
+    rgba(0, 0, 0, 0.2) 30%,
+    rgba(0, 0, 0, 0)
+  );
+  box-shadow:
+    inset 2px 2px 3px rgba(255, 255, 255, 0.6),
+    inset -2px -2px 3px rgba(0, 0, 0, 0.6);
+}
+
+.styled:hover {
+  background-color: rgba(255, 0, 0, 1);
+}
+
+.styled:active {
+  box-shadow:
+    inset -2px -2px 3px rgba(255, 255, 255, 0.6),
+    inset 2px 2px 3px rgba(0, 0, 0, 0.6);
+}
+</style>

--- a/components/Sample.vue
+++ b/components/Sample.vue
@@ -1,0 +1,3 @@
+<template>
+  <h1>Sampleコンポネントです</h1>
+</template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,0 +1,25 @@
+<template>
+  <AppHeader />
+
+  <!-- Button style="margin-top: 90px;" @click="enableSimpleLayout"/> -->
+  <AtomsButton style="margin-top: 90px;" @click="enableSimpleLayout"/>
+
+  <h1>Lazy Component</h1>
+  <button @click="showComponent = !showComponent">
+    コンポネント読み込み
+  </button>
+
+  <!--開発者ツールnetworkタブで違いを確認できる -->
+  <LazySample v-if="showComponent" />
+
+  <div>
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+const enableSimpleLayout = () => {
+  setPageLayout('simple')
+}
+const showComponent = ref(false)
+</script>

--- a/layouts/simple.vue
+++ b/layouts/simple.vue
@@ -1,0 +1,14 @@
+<template>
+  <AppHeader />
+  <div style="margin-top: 100px">
+    {{ 'Simple layout' }}
+    <AtomsButton @click="enableDefaultLayout"/>
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+const enableDefaultLayout = () => {
+  setPageLayout('default')
+}
+</script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,11 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
+//   components: [
+//     {
+//       path: '~/components',
+//       pathPrefix: false,
+//     },
+//   ],
   compatibilityDate: '2024-04-03',
   devtools: { enabled: true }
 })

--- a/pages/todo.vue
+++ b/pages/todo.vue
@@ -1,9 +1,5 @@
 <template>
   <div>
-    <header class="app-bar">
-      <div class="app-bar-title">ToDo App</div>
-    </header>
-
     <main class="main-content">
       <div class="add-todo">
         <input v-model="newTodo" placeholder="TODOを入力してください" @keyup.enter="addTodo" />
@@ -22,6 +18,9 @@
 </template>
 
 <script setup lang="ts">
+// definePageMeta({
+//   layout: 'simple'
+// })
 const newTodo = ref<string>('')
 const todos = ref<{ text: string; done: boolean }[]>([])
 
@@ -38,26 +37,6 @@ const removeTodo = (index: number) => {
 </script>
 
 <style>
-.app-bar {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 64px;
-  background-color: #1976d2;
-  color: white;
-  display: flex;
-  align-items: center;
-  padding: 0 20px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  z-index: 10;
-}
-
-.app-bar-title {
-  font-size: 24px;
-  font-weight: bold;
-}
-
 .main-content {
   margin-top: 80px;
   padding: 20px;


### PR DESCRIPTION
## 対応内容

- [x] componentsとlayoutsディレクトリの作成
- [x] app.vueにNuxtLayoutコンポネントを追加
- [x] ヘッダー部分をappHeaderに切り出す
- [x] lazy-loading a componentのサンプル
- [x] 動的にレイアウトを切り替える

## 要点
- componentsディレクトリ配下がデフォルトでauto-importされる
- その際、パスに応じたコンポネント名になるので修正したい場合はnuxt.config.tsで`pathPrefix: false`を指定する
- layoutsディレクトリ配下のdefault.vueがデフォルトで読み込まれ、`definePageMeta`でレイアウトを切り替えられる
- setPageLayoutなどで動的にレイアウトを切り替えできる
- lazy-loading a componentを使えば、初期読み込みに必要なコンポネントだけを読み込ませることができる